### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/terraform/shared-infrastructure/feeds.tf
+++ b/terraform/shared-infrastructure/feeds.tf
@@ -8,7 +8,7 @@ output "octopus_dockerhub_feed_id" {
 }
 
 resource "octopusdeploy_docker_container_registry" "github_docker_feed" {
-  feed_uri = "https://gchr.io"
+  feed_uri = "https://ghcr.io"
   name     = "GitHub Docker"
   password = var.github_feed_token
   username = var.github_username


### PR DESCRIPTION
Hi `mcasperson/AppBuilderPlayground`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.